### PR TITLE
Update broken in link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you have `pip` (which should be run in a suitable virtual environment) the fo
 ```sh
 pip install 'https://github.com/jetson-nano-wheels/python3.6-numpy-1.19.4/releases/download/v0.0.2/numpy-1.19.4-cp36-cp36m-linux_aarch64.whl'
 pip install 'https://github.com/jetson-nano-wheels/python3.6-blis-0.7.4/releases/download/v0.0.1/blis-0.7.4-cp36-cp36m-linux_aarch64.whl'
-pip install 'https://github.com/jetson-nano-wheels/python3.6-thinc-8.0.8/releases/download/v0.0.1/thinc-8.0.8-cp36-cp36m-linux_aarch64.whl'
+pip install 'https://github.com/jetson-nano-wheels/python3.6-thinc-8.0.0/releases/download/v0.0.1/thinc-8.0.8-cp36-cp36m-linux_aarch64.whl'
 ```
 
 


### PR DESCRIPTION
The name of this repository is still "python3.6-thinc-8.0.0". If you try to install thinc from the link in the readme (which has as "python3.6-thinc-8.0.**8**" in the name) you'll get a 404. I don't know whether the repository is supposed to carry version number 8.0.8, but in any case, this fixed the 404 issue I was having!